### PR TITLE
Closes issue #27

### DIFF
--- a/Interception/src/main/java/Declarations.java
+++ b/Interception/src/main/java/Declarations.java
@@ -126,6 +126,46 @@ public class Declarations {
         return false; 
     }
 
+    /*
+     * LIC 9
+     * Code for asserting the angle of three data points 
+     */
+    public boolean compute_lic_9(){
+        if(NUMPOINTS<5){
+            return false;
+        }
+        // ensure valid parameters
+        if(params.C_PTS<1 || params.D_PTS<1 || params.C_PTS+params.D_PTS > NUMPOINTS-3){
+            return false;
+        }
+        for(int i = 0; i < NUMPOINTS - params.C_PTS-params.D_PTS-2;i++){
+            int first = i;
+            int second = i + params.C_PTS+1;
+            int third = second + params.D_PTS+1;
+
+            // check if within bounds
+            if(third >= NUMPOINTS){
+                continue;
+            }
+
+            Point A = points[first];
+            Point B = points[second];
+            Point C = points[third];
+
+            // check if either the first or third point coincides with the second point, if so skip
+            if((A.x == B.x && A.y == B.y) || (C.x == B.x && C.y == B.y)){
+                continue;
+            }
+            double angle = calcAngle(A, B, C);
+
+            // check if angle satisfies conditon
+            if(angle < (Math.PI-params.EPSILON) || angle>(Math.PI+params.EPSILON)){
+                return true;
+            }
+        }
+        // default
+        return false;
+    }
 
     /*
      * Help function for calculating the area of a triangle given its three sides.
@@ -134,6 +174,33 @@ public class Declarations {
         double s = (a+b+c)/2;
         double A = Math.sqrt((s*(s-a)*(s-b)*(s-c)));
         return A; 
+    }
+
+    /*
+     * Help function for calculating the angle of three given dots using vector dot product.
+     */
+    private double calcAngle(Point A, Point B, Point C){
+        double BA_x = A.x - B.x;
+        double BA_y = A.y - B.y;
+        double BC_x = C.x - B.x;
+        double BC_y = C.y - B.y;
+
+        double dotPro = (BA_x * BC_x) + (BA_y * BC_y);
+
+        double magBA = Math.sqrt(BA_x * BA_x + BA_y * BA_y);
+        double magBC = Math.sqrt(BC_x * BC_x + BC_y * BC_y);
+
+        // check for zero division
+        if(magBA == 0 || magBC == 0){
+            return Math.PI;
+        }
+
+        // compute angle
+        double cosThe = dotPro / (magBA*magBC);
+        // clamp cosThe to valid range
+        cosThe = Math.max(-1.0,Math.min(1.0, cosThe));
+
+        return Math.acos(cosThe);
     }
 
 

--- a/Interception/src/test/java/DecideTest.java
+++ b/Interception/src/test/java/DecideTest.java
@@ -65,6 +65,37 @@ class DecideTest {
 
 
     }
+    /*
+     * Function for testing if LIC9 returns the correct boolean value.   
+     * Returns true when the three points create a angle which satisfiy angle < (PI−EPSILON) or angle > (PI+EPSILON).
+     * Returns false if the three points create a angle which does not satisfy the above statement or if NUMPOINTS < 5, 1 ≤ C PTS, 1 ≤ D PTS, C PTS+D PTS ≤ NUMPOINTS−3.
+     */
+    @Test
+    void testLic9() {
+        Parameters params = new Parameters();
+        params.C_PTS = 1;
+        params.D_PTS = 1;
+        params.EPSILON = 0.1;
+        
+        int NUMPOINTS = 5;
+        Point[] points = new Point[] {
+            new Point(0, 0),  // A (first)
+            new Point(1, 1),
+            new Point(2, 2),  // B (second)
+            new Point(3, 1),
+            new Point(4, 0)   // C (third)
+        };
+
+        Declarations declarations = new Declarations(NUMPOINTS, points, params, null, null);
+        assertTrue(declarations.compute_lic_9(), "LIC9 should return true when an angle outside the range is found");
+
+        Point[] collinearPoints = new Point[] {
+            new Point(0, 0), new Point(2, 2), new Point(4, 4), new Point(6, 6), new Point(8, 8)
+        };
+        Declarations collinearDecide = new Declarations(NUMPOINTS, collinearPoints, params, null, null);
+        assertFalse(collinearDecide.compute_lic_9(), "LIC9 should return false for collinear points");
+    }
+
    
     
 }


### PR DESCRIPTION
feat: add function for LIC9 and appropriate tests
LIC9 conditions are: "There exists at least one set of three data points separated by exactly C PTS and D PTS consecutive intervening points, respectively, that form an angle such that:
angle < (PI−EPSILON)
or
angle > (PI+EPSILON)
The second point of the set of three points is always the vertex of the angle. If either the first
point or the last point (or both) coincide with the vertex, the angle is undefined and the LIC
is not satisfied by those three points. When NUMPOINTS < 5, the condition is not met.
1 ≤ C PTS, 1 ≤ D PTS
C PTS+D PTS ≤ NUMPOINTS−3"

also added a helper function for LIC9 to calculate the angle of three given points